### PR TITLE
The current version only checks for system-defined "Content-Encoding"…

### DIFF
--- a/aws_s3--0.0.1.sql
+++ b/aws_s3--0.0.1.sql
@@ -90,9 +90,10 @@ AS $$
 
     response = s3.head_object(Bucket=bucket, Key=file_path)
     content_encoding = response.get('ContentEncoding')
+    user_content_encoding = response.get('x-amz-meta-content-encoding')
 
     with tempfile.NamedTemporaryFile() as fd:
-        if content_encoding and content_encoding.lower() == 'gzip':
+        if (content_encoding and content_encoding.lower() == 'gzip') or (user_content_encoding and user_content_encoding.lower() == 'gzip'):
             with tempfile.NamedTemporaryFile() as gzfd:
                 s3.download_fileobj(bucket, file_path, gzfd)
                 gzfd.flush()


### PR DESCRIPTION
… metadata set to "gzip" on an S3 object. Some tools do not properly set this metadata on write and AWS APIs to add metadata to an S3 object can only add it as user-defined metadata. The equivalent Amazon S3 user-defined metadata attribute is "x-amz-meta-content-encoding". This update adds an additional test for whether the user-defined metadata attribute "x-amz-meta-content-encoding" is set to "gzip".

