### PR TITLE
[PEP668] Switched pip install of boto3 to apt-get install to support PEP668

### DIFF
--- a/mock-servers/postgres/Dockerfile
+++ b/mock-servers/postgres/Dockerfile
@@ -4,7 +4,6 @@ RUN mkdir /tmp/extension
 WORKDIR /tmp/extension
 
 RUN apt-get update \ 
-    && apt-get -y install python3 python3-pip postgresql-plpython3-13 make
-RUN pip3 install boto3
+    && apt-get -y install python3 python3-pip postgresql-plpython3-13 make python3-boto3
 COPY aws_s3--0.0.1.sql aws_s3.control Makefile ./
 RUN make install


### PR DESCRIPTION
New builds of the Postgres image now produce the following error message:

```
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.
    
    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.
    
    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.
    
    See /usr/share/doc/python3.11/README.venv for more information.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.
```

This is due to Ubuntu and Debian adopting [PEP668](https://peps.python.org/pep-0668/#implementation-notes)

Instead of installing boto3 using `pip`, I've updated the Dockerfile to install it using `apt-get`. 

Please see [pip install errors on debian/ubuntu ](https://www.omgubuntu.co.uk/2023/04/pip-install-error-externally-managed-environment-fix)

